### PR TITLE
fix dev url's

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -1,9 +1,9 @@
 # Developers
 
 
-- [**Front-end**](dev/stack/front-end/) | The user-interface built in your framework of choice.
-- [**Backend**](dev/stack/back-end) | Performs the off-chain logic
-- [**Smart Contract**](#ergoscript) | Where the magic happens, the on-chain validation of the off-chain logic.
+- [**Front-end**](stack/front-end) | The user-interface built in your framework of choice.
+- [**Backend**](stack/back-end) | Performs the off-chain logic
+- [**Smart Contract**](scs/ergoscript) | Where the magic happens, the on-chain validation of the off-chain logic.
 
 ## [Ergo Improvement Proposals](https://github.com/ergoplatform/eips)
 


### PR DESCRIPTION
front and backend currently links to dev/dev/stack, smart contract do nothing